### PR TITLE
Add CI and multiple deployment targets

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,27 +1,27 @@
-# Simple workflow for deploying static content to GitHub Pages
-name: Deploy static content to Pages
+name: CD
 
 on:
-  # Runs on pushes targeting the default branch
-  push:
-    branches: ["master"]
+  workflow_call:
+    inputs:
+      base_path:
+        description: "Base path for Vite build (must include leading/trailing slash)."
+        required: true
+        type: string
+      target_dir:
+        description: "Target directory inside Pages artifact."
+        required: true
+        type: string
 
-  # Allows you to run this workflow manually from the Actions tab
-  workflow_dispatch:
-
-# Sets the GITHUB_TOKEN permissions to allow deployment to GitHub Pages
 permissions:
   contents: read
   pages: write
   id-token: write
 
-# Allow one concurrent deployment
 concurrency:
   group: "pages"
   cancel-in-progress: true
 
 jobs:
-  # Single deploy job since we're just deploying
   deploy:
     environment:
       name: github-pages
@@ -38,18 +38,26 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: lts/*
-          cache: "pnpm"
+          cache: pnpm
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Build
+        env:
+          VITE_BASE: ${{ inputs.base_path }}
         run: pnpm run build
+      - name: Prepare Pages artifact
+        shell: bash
+        run: |
+          set -euo pipefail
+          pages_dir=".pages/${{ inputs.target_dir }}"
+          mkdir -p "${pages_dir}"
+          cp -R dist/. "${pages_dir}/"
       - name: Setup Pages
         uses: actions/configure-pages@v5
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v4
         with:
-          # Upload dist folder
-          path: "./dist"
+          path: ./.pages
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -8,7 +8,7 @@ on:
         required: true
         type: string
       target_dir:
-        description: "Target directory inside Pages artifact."
+        description: "Target directory inside Pages artifact (empty for root)."
         required: true
         type: string
 
@@ -49,7 +49,12 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          pages_dir=".pages/${{ inputs.target_dir }}"
+          pages_root=".pages"
+          if [[ -n "${{ inputs.target_dir }}" && "${{ inputs.target_dir }}" != "." ]]; then
+            pages_dir="${pages_root}/${{ inputs.target_dir }}"
+          else
+            pages_dir="${pages_root}"
+          fi
           mkdir -p "${pages_dir}"
           cp -R dist/. "${pages_dir}/"
       - name: Setup Pages

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - "**"
+  workflow_dispatch:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  checks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+      - name: Set up Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: lts/*
+          cache: pnpm
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Lint
+        run: pnpm run lint
+      - name: Build
+        run: pnpm run build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,6 @@
 name: CI
 
 on:
-  pull_request:
-    branches:
-      - "**"
   workflow_dispatch:
   workflow_call:
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,10 +3,18 @@ name: Release
 on:
   push:
     branches:
+      - "master"
+  pull_request:
+    branches:
       - "**"
   release:
     types: [published]
   workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "PR number to deploy (for feature previews)"
+        required: false
+        type: string
 
 permissions:
   contents: read
@@ -28,23 +36,30 @@ jobs:
         run: |
           set -euo pipefail
 
+          pr_number="${{ github.event.pull_request.number }}"
+          manual_pr="${{ github.event.inputs.pr_number }}"
+
           if [[ "${GITHUB_EVENT_NAME}" == "release" ]]; then
             base_path="/kami/"
             target_dir="kami"
+          elif [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
+            if [[ -z "${pr_number}" ]]; then
+              echo "PR number missing; cannot determine feature deploy target." >&2
+              exit 1
+            fi
+            base_path="/kami-feat${pr_number}/"
+            target_dir="kami-feat${pr_number}"
+          elif [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" && -n "${manual_pr}" ]]; then
+            base_path="/kami-feat${manual_pr}/"
+            target_dir="kami-feat${manual_pr}"
           else
             branch="${GITHUB_REF#refs/heads/}"
             if [[ "${branch}" == "master" ]]; then
               base_path="/kami-master/"
               target_dir="kami-master"
             else
-              if [[ "${branch}" =~ ([0-9]+) ]]; then
-                num="${BASH_REMATCH[1]}"
-                base_path="/kami-feat${num}/"
-                target_dir="kami-feat${num}"
-              else
-                echo "Branch '${branch}' must include a number for feature deployments." >&2
-                exit 1
-              fi
+              echo "Feature deployments use PR numbers; open a PR or pass pr_number on workflow_dispatch." >&2
+              exit 1
             fi
           fi
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,22 +40,22 @@ jobs:
           manual_pr="${{ github.event.inputs.pr_number }}"
 
           if [[ "${GITHUB_EVENT_NAME}" == "release" ]]; then
-            base_path="/"
+            base_path="/kami/"
             target_dir=""
           elif [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
             if [[ -z "${pr_number}" ]]; then
               echo "PR number missing; cannot determine feature deploy target." >&2
               exit 1
             fi
-            base_path="/feat${pr_number}/"
+            base_path="/kami/feat${pr_number}/"
             target_dir="feat${pr_number}"
           elif [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" && -n "${manual_pr}" ]]; then
-            base_path="/feat${manual_pr}/"
+            base_path="/kami/feat${manual_pr}/"
             target_dir="feat${manual_pr}"
           else
             branch="${GITHUB_REF#refs/heads/}"
             if [[ "${branch}" == "master" ]]; then
-              base_path="/master/"
+              base_path="/kami/master/"
               target_dir="master"
             else
               echo "Feature deployments use PR numbers; open a PR or pass pr_number on workflow_dispatch." >&2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,64 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - "**"
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  ci:
+    uses: ./.github/workflows/ci.yml
+
+  prepare-deploy:
+    needs: ci
+    runs-on: ubuntu-latest
+    outputs:
+      base_path: ${{ steps.vars.outputs.base_path }}
+      target_dir: ${{ steps.vars.outputs.target_dir }}
+    steps:
+      - id: vars
+        name: Resolve deploy target
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ "${GITHUB_EVENT_NAME}" == "release" ]]; then
+            base_path="/kami/"
+            target_dir="kami"
+          else
+            branch="${GITHUB_REF#refs/heads/}"
+            if [[ "${branch}" == "master" ]]; then
+              base_path="/kami-master/"
+              target_dir="kami-master"
+            else
+              if [[ "${branch}" =~ ([0-9]+) ]]; then
+                num="${BASH_REMATCH[1]}"
+                base_path="/kami-feat${num}/"
+                target_dir="kami-feat${num}"
+              else
+                echo "Branch '${branch}' must include a number for feature deployments." >&2
+                exit 1
+              fi
+            fi
+          fi
+
+          echo "base_path=${base_path}" >> "$GITHUB_OUTPUT"
+          echo "target_dir=${target_dir}" >> "$GITHUB_OUTPUT"
+
+  deploy:
+    needs: [ci, prepare-deploy]
+    uses: ./.github/workflows/cd.yml
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    secrets: inherit
+    with:
+      base_path: ${{ needs.prepare-deploy.outputs.base_path }}
+      target_dir: ${{ needs.prepare-deploy.outputs.target_dir }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,23 +40,23 @@ jobs:
           manual_pr="${{ github.event.inputs.pr_number }}"
 
           if [[ "${GITHUB_EVENT_NAME}" == "release" ]]; then
-            base_path="/kami/"
-            target_dir="kami"
+            base_path="/"
+            target_dir=""
           elif [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
             if [[ -z "${pr_number}" ]]; then
               echo "PR number missing; cannot determine feature deploy target." >&2
               exit 1
             fi
-            base_path="/kami-feat${pr_number}/"
-            target_dir="kami-feat${pr_number}"
+            base_path="/feat${pr_number}/"
+            target_dir="feat${pr_number}"
           elif [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" && -n "${manual_pr}" ]]; then
-            base_path="/kami-feat${manual_pr}/"
-            target_dir="kami-feat${manual_pr}"
+            base_path="/feat${manual_pr}/"
+            target_dir="feat${manual_pr}"
           else
             branch="${GITHUB_REF#refs/heads/}"
             if [[ "${branch}" == "master" ]]; then
-              base_path="/kami-master/"
-              target_dir="kami-master"
+              base_path="/master/"
+              target_dir="master"
             else
               echo "Feature deployments use PR numbers; open a PR or pass pr_number on workflow_dispatch." >&2
               exit 1

--- a/vite.config.js
+++ b/vite.config.js
@@ -3,9 +3,12 @@ import { defineConfig } from "vite";
 const host = process.env.TAURI_DEV_HOST;
 const isTauri = Boolean(process.env.TAURI_ENV_PLATFORM || host);
 
+const webBase = process.env.VITE_BASE || "/kami/";
+const normalizedWebBase = webBase.endsWith("/") ? webBase : `${webBase}/`;
+
 // https://vitejs.dev/config/
 export default defineConfig({
-  base: isTauri ? "./" : "/kami/",
+  base: isTauri ? "./" : normalizedWebBase,
   clearScreen: false,
   server: {
     port: 1420,


### PR DESCRIPTION
This pull request introduces a new, modular GitHub Actions workflow setup for CI, CD, and release processes, with improved flexibility for feature branch deployments and dynamic Vite base paths. The workflows are now more reusable and support deploying multiple feature branches to separate paths.

**Workflow Refactoring and Deployment Improvements:**

* The deployment workflow was renamed from `deploy.yml` to `cd.yml`, refactored to use `workflow_call` inputs for dynamic base paths and target directories, and now prepares artifacts for multi-branch deployments. [[1]](diffhunk://#diff-ea3ea8c9932adc7ba8161ceda844fedd43b006848ef1140c050cbd7ea0788a18L1-L24) [[2]](diffhunk://#diff-ea3ea8c9932adc7ba8161ceda844fedd43b006848ef1140c050cbd7ea0788a18L41-R60)
* A new `release.yml` workflow orchestrates CI, resolves deployment targets based on branch or release, and triggers the CD workflow with the appropriate parameters, supporting feature branch deployments with enforced branch naming conventions.
* A new `ci.yml` workflow provides a reusable CI pipeline for linting and building, used by both pull requests and the release workflow.

**Vite Configuration Enhancement:**

* The `vite.config.js` file now reads the deployment base path from the `VITE_BASE` environment variable, allowing dynamic configuration of the base URL for different deployment targets.