### PR TITLE
Inherit secrets in macos and cd release jobs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,7 @@ jobs:
   macos:
     needs: [ci]
     uses: ./.github/workflows/macos.yml
+    secrets: inherit
     permissions:
       contents: write
 
@@ -27,6 +28,7 @@ jobs:
   cd:
     needs: [ci]
     uses: ./.github/workflows/deploy.yml
+    secrets: inherit
     permissions:
       contents: read
       pages: write


### PR DESCRIPTION
## Summary
- The `macos` and `cd` jobs in `release.yml` call reusable workflows without `secrets: inherit`, so `VITE_POSTHOG_KEY`/`VITE_POSTHOG_HOST` (and any macOS signing secrets) resolved empty during the v0.0.3 release build.
- Confirmed in the run logs: `VITE_POSTHOG_KEY: ` was blank in both the `cd / deploy` and `macos / build-macos` steps.
- As a result, the prod deploy (kami.maxwase.eu) and macOS build never got a PostHog key, so no analytics events reach the project from either.

## Test plan
- [ ] Merge this PR
- [ ] Delete and recreate the v0.0.3 release to re-trigger the release workflow
- [ ] Confirm `VITE_POSTHOG_KEY`/`VITE_POSTHOG_HOST` are non-empty in the new run's logs
- [ ] Confirm prod (kami.maxwase.eu) starts sending PostHog events